### PR TITLE
chore: clean egg-info artefacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ inbox/
 .coverage
 htmlcov/
 coverage.xml
+
+# Build artefacts
+*.egg-info/


### PR DESCRIPTION
Delete stray src/agent_system.egg-info and add *.egg-info/ to .gitignore to keep repo clean.