### PR TITLE
Fix pytest hook cache use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ inbox/
 .coverage.*
 htmlcov/
 coverage.xml
+.pytest_cache/
 
 # Build artefacts
 *.egg-info/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,10 @@ repos:
     hooks:
       - id: pytest
         name: pytest quick
-        entry: bash -c 'if [[ -n "$SKIP_TEST_HOOKS" ]]; then exit 0; fi; COVERAGE_FILE="/tmp/.coverage_precommit" pytest -q --maxfail=1 --no-cov'
+        entry: >-
+          bash -c 'if [[ -n "$SKIP_TEST_HOOKS" ]]; then exit 0; fi;
+          PYTEST_ADDOPTS="" COVERAGE_FILE="/tmp/.coverage_precommit" pytest -q
+          --maxfail=1 -p no:cacheprovider --no-cov'
         language: system
         pass_filenames: false
   - repo: local


### PR DESCRIPTION
## Summary
- prevent `.pytest_cache` from being tracked
- force pytest pre-commit hook to run without cache or coverage

## Testing
- `pre-commit run --files .pre-commit-config.yaml .gitignore` *(fails: command not found)*